### PR TITLE
refactor(installation.md): Update `RoadRunner` version to `2025.1.2` and adjust project structure example.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 - [`PHP`](https://www.php.net/downloads) 8.1 or higher.
 - [`Composer`](https://getcomposer.org/download/) for dependency management.
-- [`RoadRunner`](https://github.com/roadrunner-server/roadrunner) 2024.3.0 or higher.
+- [`RoadRunner`](https://github.com/roadrunner-server/roadrunner) 2025.1.2 or higher.
 - [`Yii2`](https://github.com/yiisoft/yii2) 2.0.53+ or 22.x.
 
 ## Installation
@@ -50,8 +50,8 @@ curl -sSL https://github.com/roadrunner-server/roadrunner/releases/latest/downlo
 Organize your project for RoadRunner:
 
 ```text
-your-project/
-├── public/
+app-basic/
+├── web/
 │   └── index.php          # RoadRunner entry point
 ├── .rr.yaml               # RoadRunner configuration
 └── rr                     # RoadRunner binary


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the minimum required version of RoadRunner to 2025.1.2 or higher in the system requirements.
  * Revised the example project directory structure to use "app-basic" as the root folder and renamed the entry point subdirectory from "public" to "web".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->