### PR TITLE
fix: Update workflow actions to use `v1` stable version instead of `main`, update `LICENSE.md`.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -35,8 +35,8 @@
 /composer-require-checker.json  export-ignore
 /docs                           export-ignore
 /ecs.php                        export-ignore
-/infection.json5                export-ignore
-/phpstan*.neon                  export-ignore
+/infection.json*                export-ignore
+/phpstan*.neon*                 export-ignore
 /phpunit.xml.dist               export-ignore
 /psalm.xml                      export-ignore
 /rector.php                     export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ name: build
 
 jobs:
   phpunit:
-    uses: php-forge/actions/.github/workflows/phpunit.yml@main
+    uses: php-forge/actions/.github/workflows/phpunit.yml@v1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -19,4 +19,4 @@ name: Composer require checker
 
 jobs:
   composer-require-checker:
-    uses: php-forge/actions/.github/workflows/composer-require-checker.yml@main
+    uses: php-forge/actions/.github/workflows/composer-require-checker.yml@v1

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -19,4 +19,4 @@ name: ecs
 
 jobs:
   easy-coding-standard:
-    uses: php-forge/actions/.github/workflows/ecs.yml@main
+    uses: php-forge/actions/.github/workflows/ecs.yml@v1

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -19,7 +19,7 @@ name: mutation test
 
 jobs:
   mutation:
-    uses: php-forge/actions/.github/workflows/infection.yml@main
+    uses: php-forge/actions/.github/workflows/infection.yml@v1
     with:
       phpstan: true
     secrets:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -19,4 +19,4 @@ name: static analysis
 
 jobs:
   phpstan:
-    uses: php-forge/actions/.github/workflows/phpstan.yml@main
+    uses: php-forge/actions/.github/workflows/phpstan.yml@v1

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,9 +11,9 @@ are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice, 
   this list of conditions and the following disclaimer in the documentation 
   and/or other materials provided with the distribution.
-* Neither the name of Yii Software nor the names of its contributors may be 
-  used to endorse or promote products derived from this software without 
-  specific prior written permission.
+* Neither the name of Yii2 Extensions (Terabytesoftw) nor the names of its 
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "yii2-extensions/psr-bridge": "^0.1@dev"
     },
     "require-dev": {
-        "infection/infection": "^0.27|^0.30",
+        "infection/infection": "^0.27|^0.31",
         "httpsoft/http-message": "^1.1",
         "maglnet/composer-require-checker": "^4.1",
         "phpstan/extension-installer": "^1.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
