### PR TITLE
fix(docs): Add server start instructions and enhance file upload handling in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ metrics:
     address: '127.0.0.1:2112'
 ```
 
+### Start the server
+
+```bash
+# install RoadRunner binary
+vendor/bin/rr get
+
+# start the server
+./rr serve
+```
+
 ### Development & Debugging
 
 For enhanced debugging capabilities and proper time display in RoadRunner, install the worker debug extension.
@@ -148,14 +158,31 @@ if (YII_ENV_DEV) {
 }
 ```
 
-### Start the server
+### File Upload Handling
 
-```bash
-# install RoadRunner binary
-vendor/bin/rr get
+For enhanced file upload support in worker environments, use the PSR-7 bridge UploadedFile class instead of the standard 
+Yii2 implementation.
 
-# start the server
-./rr serve
+```php
+<?php
+
+declare(strict_types=1);
+
+use yii2\extensions\psrbridge\http\{Response, UploadedFile};
+
+final class FileController extends \yii\web\Controller
+{
+    public function actionUpload(): Response
+    {
+        $file = UploadedFile::getInstanceByName('avatar');
+        
+        if ($file !== null && $file->error === UPLOAD_ERR_OK) {
+            $file->saveAs('@webroot/uploads/' . $file->name);
+        }
+        
+        return $this->asJson(['status' => 'uploaded']);
+    }
+}
 ```
 
 Your application will be available at `http://localhost:8080`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to demonstrate file upload handling with a PHP example using PSR-7 in a Yii2 controller, including saving uploads and returning a JSON response.
  * Replaced the shell-based server start snippet with guidance on using the PSR-7 bridge for uploads.
  * Retained note that the application will be available at http://localhost:8080.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->