### PR TITLE
fix(docs): Clarify application availability in `README.md` after server start instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ vendor/bin/rr get
 ./rr serve
 ```
 
-Your application will be available at `http://127.0.0.1:8080` (or `http://localhost:8080`) or at the address set in 
+> Your applicaion will be available at `http://127.0.0.1:8080` (or `http://localhost:8080`) or at the address set in 
 `http.address` in `.rr.yaml`.
 
 ### Development & Debugging

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ vendor/bin/rr get
 ./rr serve
 ```
 
+Your application will be available at `http://localhost:8080` or the address you specified in `.rr.yaml`.
+
 ### Development & Debugging
 
 For enhanced debugging capabilities and proper time display in RoadRunner, install the worker debug extension.
@@ -184,8 +186,6 @@ final class FileController extends \yii\web\Controller
     }
 }
 ```
-
-Your application will be available at `http://localhost:8080`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ vendor/bin/rr get
 ./rr serve
 ```
 
-Your application will be available at `http://localhost:8080` or the address you specified in `.rr.yaml`.
+Your application will be available at `http://127.0.0.1:8080` (or `http://localhost:8080`) or at the address set in 
+`http.address` in `.rr.yaml`.
 
 ### Development & Debugging
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified post-startup access instructions by stating the default URL (http://127.0.0.1:8080 or http://localhost:8080) and that the address is configurable.
  * Removed a redundant earlier access line to reduce confusion and improve readability.
  * Improves onboarding by making it clearer where to reach the app after starting the server.
  * No functional, API, or behavioral changes; documentation-only update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->