### PR TITLE
fix(docs): Correct command syntax for running PHPStan in `testing.md`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.2 Under development
 
 - Bug #33: Update examples in `testing.md` for running Composer script with arguments (@terabytesoftw)
+- Bug #34: Correct command syntax for running PHPStan in `testing.md` (@terabytesoftw)
 
 ## 0.1.1 January 25, 2026
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -78,5 +78,5 @@ composer tests -- --coverage-html code_coverage
 Example: run PHPStan with a different memory limit:
 
 ```bash
-composer run static -- --memory-limit=512M
+composer static -- --memory-limit=512M
 ```


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected command syntax for static analysis in testing documentation, ensuring developers follow the accurate workflow for code quality checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->