### PR TITLE
fix(docs): Update command syntax in `testing.md` to remove redundant 'run' prefix for Composer scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug #33: Update examples in `testing.md` for running Composer script with arguments (@terabytesoftw)
 - Bug #34: Correct command syntax for running PHPStan in `testing.md` (@terabytesoftw)
+- Bug #35: Update command syntax in `testing.md` to remove redundant 'run' prefix for Composer scripts (@terabytesoftw)
 
 ## 0.1.1 January 25, 2026
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,7 +16,7 @@ Tool references:
 Run Rector to apply automated code refactoring.
 
 ```bash
-composer run rector
+composer rector
 ```
 
 ## Coding standards (ECS)
@@ -24,7 +24,7 @@ composer run rector
 Run Easy Coding Standard (ECS) and apply fixes.
 
 ```bash
-composer run ecs
+composer ecs
 ```
 
 ## Dependency definition check
@@ -32,7 +32,7 @@ composer run ecs
 Verify that runtime dependencies are correctly declared in `composer.json`.
 
 ```bash
-composer run check-dependencies
+composer check-dependencies
 ```
 
 ## Mutation testing (Infection)
@@ -40,13 +40,13 @@ composer run check-dependencies
 Run mutation testing.
 
 ```bash
-composer run mutation
+composer mutation
 ```
 
 Run mutation testing with static analysis enabled.
 
 ```bash
-composer run mutation-static
+composer mutation-static
 ```
 
 ## Static analysis (PHPStan)
@@ -54,7 +54,7 @@ composer run mutation-static
 Run static analysis.
 
 ```bash
-composer run static
+composer static
 ```
 
 ## Unit tests (PHPUnit)
@@ -62,7 +62,7 @@ composer run static
 Run the full test suite.
 
 ```bash
-composer run tests
+composer tests
 ```
 
 ## Passing extra arguments


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing documentation with simplified Composer command syntax, removing the redundant 'run' prefix from script invocations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->