### PR TITLE
fix(roadrunner): Update `RoadRunner` constructor to `bootstrapContainer()` before worker instantiation.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,10 +21,6 @@
 *.gif  binary
 *.ttf  binary
 
-# Avoid merge conflicts in CHANGELOG
-# https://about.gitlab.com/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/
-/CHANGELOG.md		merge=union
-
 # Exclude files from the archive
 /.editorconfig                  export-ignore
 /.gitattributes                 export-ignore
@@ -38,7 +34,10 @@
 /infection.json*                export-ignore
 /phpstan*.neon*                 export-ignore
 /phpunit.xml.dist               export-ignore
-/psalm.xml                      export-ignore
 /rector.php                     export-ignore
 /runtime                        export-ignore
 /tests                          export-ignore
+
+# Avoid merge conflicts in CHANGELOG
+# https://about.gitlab.com/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/
+/CHANGELOG.md merge=union

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ package-lock.json
 # phpstorm project (if present)
 .idea
 
+# phpactor (if present)
+.phpactor.*
+
 # phpunit (if present)
 .phpunit.cache
 .phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ChangeLog
 
-## 0.2.1 Under development
+## 0.3.0 Under development
+
+- Bug #44: Update `RoadRunner` constructor to `bootstrapContainer()` before worker instantiation (@terabytesoftw)
 
 ## 0.2.0 February 20, 2026
 

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,0 +1,3 @@
+{
+    "symbol-whitelist": ["Yii"]
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "spiral/roadrunner-cli": "^2.7",
         "spiral/roadrunner-http": "^v4.0",
         "spiral/roadrunner-worker": "^3.6",
-        "yii2-extensions/psr-bridge": "^0.2"
+        "yii2-extensions/psr-bridge": "^0.3@dev"
     },
     "require-dev": {
         "infection/infection": "^0.27|^0.32",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
   stopOnFailure="false"
 >
   <testsuites>
-    <testsuite name="RoadRunner">
+    <testsuite name="Yii2Extensions-RoadRunner">
       <directory>tests</directory>
     </testsuite>
   </testsuites>

--- a/src/RoadRunner.php
+++ b/src/RoadRunner.php
@@ -6,6 +6,7 @@ namespace yii2\extensions\roadrunner;
 
 use Spiral\RoadRunner\Http\PSR7WorkerInterface;
 use Throwable;
+use Yii;
 use yii\web\IdentityInterface;
 use yii2\extensions\psrbridge\http\{Application, ServerExitCode};
 
@@ -46,7 +47,8 @@ final class RoadRunner
      */
     public function __construct(private readonly Application $app)
     {
-        $this->worker = $this->app->container()->get(PSR7WorkerInterface::class);
+        $app->bootstrapContainer();
+        $this->worker = Yii::$container->get(PSR7WorkerInterface::class);
     }
 
     /**


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ✔️                                                              |
